### PR TITLE
Change instance profile to remove extra http

### DIFF
--- a/portal/templates/instance_profile.html
+++ b/portal/templates/instance_profile.html
@@ -61,7 +61,7 @@
                     <td><a href="{{addr}}" target="_blank">{{service['externalIP']}}</a></td>
                     <td>{{service['clusterIP']}}</td>
                     <td>{{service['ports']}}</td>
-                    <td><a href="http://{{service['url']}}" target="_blank">{{service['url']}}</a></td>
+                    <td><a href="{{service['url']}}" target="_blank">{{service['url']}}</a></td>
                   </tr>
                   {% endfor %}
                 </tbody>


### PR DESCRIPTION
On the instances page there was an extra http:// that made the link not work, this patch fixes the error