### PR TITLE
Cli access refresh

### DIFF
--- a/portal/templates/cli_access.html
+++ b/portal/templates/cli_access.html
@@ -16,28 +16,21 @@
         <h2>CLI Access</h2>
         <p class="lead">
           <ul>
-            <li>Run the following script to install your SLATE access token on a computer where you want to use the client program (Click button below to copy script to clipboard)</li>
-            <li>Download the client executable binary suitable for your system: <a href="https://jenkins.slateci.io/artifacts/client/slate-linux.tar.gz" target="
-              ">Linux</a> or <a href="https://jenkins.slateci.io/artifacts/client/slate-macos.tar.gz" target="_blank">MacOS (version 10.9+)</a></li>
-          </ul>
-        </p>
+            <li>Run the following script to install your SLATE access token on a computer where you want to use the client program (Click button below to copy script to clipboard)
+              <div id="accordion">
+                <div class="card">
+                  <div class="card-header" id="headingOne">
+                    <h5 class="mb-0">
+                      <button class="btn btn-link" data-toggle="collapse" data-target="#collapseOne" aria-expanded="true" aria-controls="collapseOne">
+                        Run this script to install your access token
+                      </button>
+                    </h5>
+                  </div>
 
-        <hr/>
-
-        <div id="accordion">
-          <div class="card">
-            <div class="card-header" id="headingOne">
-              <h5 class="mb-0">
-                <button class="btn btn-link" data-toggle="collapse" data-target="#collapseOne" aria-expanded="true" aria-controls="collapseOne">
-                  Run this script to install your access token
-                </button>
-              </h5>
-            </div>
-
-            <div id="collapseOne" class="collapse show" aria-labelledby="headingOne" data-parent="#accordion">
-              <div class="card-body">
-                <!-- <textarea id="pubtoken" readonly disabled font-size="16"></textarea> -->
-                <textarea type="text" id="cli_access">
+                  <div id="collapseOne" class="collapse show" aria-labelledby="headingOne" data-parent="#accordion">
+                    <div class="card-body">
+                      <!-- <textarea id="pubtoken" readonly disabled font-size="16"></textarea> -->
+                      <textarea type="text" id="cli_access">
 #!/bin/sh
 mkdir -p -m 0700 "$HOME/.slate"
 if [ "$?" -ne 0 ] ; then
@@ -54,13 +47,50 @@ chmod 600 "$HOME/.slate/token"
 echo '{{slate_api_endpoint}}' > ~/.slate/endpoint
 
 echo "SLATE access token successfully stored"
-                </textarea>
-                <button class="btn btn-primary" onclick="myFunction()">Copy Script to Clipboard</button>
+                      </textarea>
+                      <button class="btn btn-primary" onclick="myFunction()">Copy Script to Clipboard</button>
 
+                    </div>
+                  </div>
+                </div>
               </div>
-            </div>
-          </div>
-        </div>
+            </li>
+            <li>Download the client executable binary suitable for your system:
+              <a href="https://jenkins.slateci.io/artifacts/client/slate-linux.tar.gz" target="">Linux</a>
+              (<a href="https://jenkins.slateci.io/artifacts/client/slate-linux.sha256" target="">checksum</a>) or
+              <a href="https://jenkins.slateci.io/artifacts/client/slate-macos.tar.gz" target="">MacOS (version 10.9+)</a>
+              (<a href="https://jenkins.slateci.io/artifacts/client/slate-macos.sha256" target="">checksum</a>)
+              <ul>
+                <li>From the command line on Linux you can download, verify, and install the client as follows:
+                  <code><pre>
+# Download the client program tarball
+curl -LO https://jenkins.slateci.io/artifacts/client/slate-linux.tar.gz
+# Download the client checksum
+curl -LO https://jenkins.slateci.io/artifacts/client/slate-linux.sha256
+# Verify the tarball: This should report that the checksum is OK
+sha256sum -c slate-linux.sha256
+# Unpack the tarball
+tar xzvf slate-linux.tar.gz
+# At this point you can move the slate binary where ever you want
+                  </pre></code>
+                </li>
+                <li>From the command line on MacOS you can download, verify, and install the client as follows:
+                  <code><pre>
+# Download the client program tarball
+curl -LO https://jenkins.slateci.io/artifacts/client/slate-macos.tar.gz
+# Download the client checksum
+curl -LO https://jenkins.slateci.io/artifacts/client/slate-macos.sha256
+# Verify the tarball: This should report that the checksum is OK
+shasum -a256 -c slate-macos.sha256
+# Unpack the tarball
+tar xzvf slate-macos.tar.gz
+# At this point you can move the slate binary where ever you want
+                  </pre></code>
+                </li>
+              </ul>
+            </li>
+          </ul>
+        </p>
       </div>
 
     </div>
@@ -68,7 +98,6 @@ echo "SLATE access token successfully stored"
 </section>
 
 <script>
-
 
 function myFunction() {
   /* Get the text field */
@@ -79,9 +108,6 @@ function myFunction() {
 
   /* Copy the text inside the text field */
   document.execCommand("copy");
-
-  /* Alert the copied text */
-  // alert("Copied the text: " + copyText.value);
 }
 
 </script>


### PR DESCRIPTION
Here is a draft I threw together of a reworking of the CLI access page. I've added guides on downloading the client from the command line, and verifying its checksum. I've also reordered the content on the page, into what I hoped might be a better order, but I may have messed up formatting in the process. 