### PR TITLE
Unlink instance service URL

### DIFF
--- a/portal/templates/instance_profile.html
+++ b/portal/templates/instance_profile.html
@@ -66,7 +66,7 @@
                       <td><a href="{{addr}}" target="_blank">{{service['externalIP']}}</a></td>
                       <td>{{service['clusterIP']}}</td>
                       <td>{{service['ports']}}</td>
-                      <td><a href="{{service['url']}}" target="_blank">{{service['url']}}</a></td>
+                      <td>{{service['url']}}</td>
                     </tr>
                     {% endfor %}
                   </tbody>


### PR DESCRIPTION
Described in https://slateci.slack.com/archives/G0194080340/p1615564691041700

Treating the 'URL' field from SLATE (which is really just an IP:Port with no protocol prefix) as linkable causes a bad relative link.

For now this fix simply removes the link. In the future, this should be updated with a copy-able text mechanism for ease of use..