### PR TITLE
New lightweight /healthz for GKE

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,6 +9,6 @@ on:
 jobs:
   lint-scan:
     name: Lint/scan image
-    uses: slateci/github-actions/.github/workflows/image-lint-scan.yml@master
+    uses: slateci/github-actions/.github/workflows/image-lint-scan.yml@v1
     with:
       file: ./resources/docker/Dockerfile

--- a/portal/templates/healthz.html
+++ b/portal/templates/healthz.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+  <p><a href="{{url_for('dashboard')}}">Log into the SLATE Portal</a></p>
+</body>
+</html>

--- a/portal/views.py
+++ b/portal/views.py
@@ -147,6 +147,10 @@ def faq():
     """FAQs page"""
     return render_template('faq.html')
 
+@app.route('/healthz', methods=['GET'])
+def healthz():
+    """Healthz page"""
+    return render_template('healthz.html')
 
 @app.route('/signup', methods=['GET'])
 def signup():


### PR DESCRIPTION
* Reusable GitHub actions now referenced by tag.
* New lightweight `/healthz` endpoint for GKE health checks to avoid errors described in #110.