### PR TITLE
Add annotations and settings for opentelemetry

### DIFF
--- a/resources/chart/templates/deployment.yml
+++ b/resources/chart/templates/deployment.yml
@@ -19,6 +19,7 @@ spec:
     metadata:
       annotations:
         checksum/secret_portal-conf: {{ include (print $.Template.BasePath "/secrets/portal-conf.yml") . | sha256sum }}
+        instrumentation.opentelemetry.io/inject-python: "true"
       labels:
         {{- include "helm-slate-portal.labels" . | nindent 8 }}
     spec:

--- a/resources/chart/templates/opentelemetry.yml
+++ b/resources/chart/templates/opentelemetry.yml
@@ -1,0 +1,16 @@
+apiVersion: opentelemetry.io/v1alpha1
+kind: Instrumentation
+metadata:
+  name: slate-instrumentation
+spec:
+  exporter:
+    endpoint: {{ .Values.opentelemetryCollector }}
+  propagators:
+    - tracecontext
+    - baggage
+    - b3
+  sampler:
+    type: parentbased_traceidratio
+    argument: "0.25"
+  python:
+    image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-python:latest


### PR DESCRIPTION
This auto-injects the opentelemetry code into the portal frontend so that we can get metrics from it