### PR TITLE
Tell Python to send stdout/stderr streams straight to terminal

### DIFF
--- a/resources/chart/templates/secrets/portal-conf.yml
+++ b/resources/chart/templates/secrets/portal-conf.yml
@@ -16,6 +16,6 @@ stringData:
     PORTAL_CLIENT_SECRET = '{{ .Values.portalClientSecret }}'
     PORTAL_VERSION = '{{ .Chart.AppVersion }}'
     SECRET_KEY = '{{ .Values.secretKey }}'
-    SERVER_NAME = '{{ .Values.portalEndpoint }}'
+    SERVER_NAME = '{{ .Values.portalEndpoint }}:443'
     SLATE_API_ENDPOINT = 'https://{{ .Values.apiEndpoint }}'
     SLATE_API_TOKEN = '{{ .Values.apiToken }}'

--- a/resources/docker/Dockerfile
+++ b/resources/docker/Dockerfile
@@ -14,6 +14,7 @@ ARG port
 
 # Container environmental variables:
 ENV FLASK_PORT=${port}
+ENV PYTHONUNBUFFERED=1
 
 # Package installs/updates:
 RUN dnf install -y epel-release


### PR DESCRIPTION
Hoping this will help with the Portal logs and the underlying `werkzeug` logging being treated as errors.

References:
* [What is the use of PYTHONUNBUFFERED in docker file?](https://stackoverflow.com/questions/59812009/what-is-the-use-of-pythonunbuffered-in-docker-file)