### PR TITLE
Emphasize that client needs IPv4

### DIFF
--- a/portal/templates/cli_access.html
+++ b/portal/templates/cli_access.html
@@ -58,6 +58,7 @@ echo "SLATE access token successfully stored"
         </div>
         <h3 class="h5">Basic Use</h3>
         <p>Check out the <a href="https://slateci.io/docs/tools">SLATE website</a> for instructions on using the SLATE Remote Client.</p>
+        <p>Important note: Please be aware that the CLI must execute on a host with an IPv4 address. This means that if your machine does not have an IPv4 address, the client program may not function properly. To ensure that the client program works as intended, please make sure that the host on which you want to run the client has an IPv4 address assigned to it before installing the client.</p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
We need to emphasize that the SLATE client must execute on a host with an IPv4. For this added a note to the SLATE CLI install page on the website.