### PR TITLE
Automate RSS Feed on Portal

### DIFF
--- a/portal/static/news.md
+++ b/portal/static/news.md
@@ -1,5 +1,0 @@
-New blog posts: 
-- [Using SLATE with JupyterLab and Open Science Grid](https://slateci.io/blog/jupyterlab-and-osg-condor-pool.html)
-- [SLATE API/Client v1.0.40](https://slateci.io/blog/2022-12-13-slate-apiclient-1040.html)
-- [Using SLATE with HTCondor and JupyterLab](https://slateci.io/blog/slate-jupyter-condor-june-2020.html)
-- [Using SLATE to deploy Varnish](https://slateci.io/blog/varnish.html)

--- a/portal/views.py
+++ b/portal/views.py
@@ -4,8 +4,8 @@ import os
 import sys
 import time
 from datetime import datetime
-import feedparser
 
+import feedparser
 import requests
 from flask import flash, jsonify, redirect, render_template, request, session, url_for
 

--- a/portal/views.py
+++ b/portal/views.py
@@ -4,6 +4,7 @@ import os
 import sys
 import time
 from datetime import datetime
+import feedparser
 
 import requests
 from flask import flash, jsonify, redirect, render_template, request, session, url_for
@@ -256,8 +257,11 @@ def dashboard():
         else:
             clusters = ["uutah-prod", "uchicago-prod", "umich-prod"]
 
-        with open("portal/static/news.md", "r") as file:
-            news = file.read()
+        feed = feedparser.parse('https://slateci.io/feed.xml')
+        news = "New blog posts: \n"
+        for i in range(4):
+            entry = feed.entries[i]
+            news += f"- [{entry.title}]({entry.link})\n"
         # This json conversion is for JS to read on the frontend
         clusters_list = json.dumps(clusters)
 

--- a/portal/views.py
+++ b/portal/views.py
@@ -257,7 +257,7 @@ def dashboard():
         else:
             clusters = ["uutah-prod", "uchicago-prod", "umich-prod"]
 
-        feed = feedparser.parse('https://slateci.io/feed.xml')
+        feed = feedparser.parse("https://slateci.io/feed.xml")
         news = "New blog posts: \n"
         for i in range(4):
             entry = feed.entries[i]

--- a/resources/docker/environment.yml
+++ b/resources/docker/environment.yml
@@ -10,6 +10,7 @@ dependencies:
       - Flask-Markdown
       - Flask-Misaka
       - Flask-WTF
+      - feedparser==6.0.10
       - black==23.3.0
       - globus-sdk==2.0.1
       - geopy

--- a/resources/docker/requirements.txt
+++ b/resources/docker/requirements.txt
@@ -2,6 +2,7 @@ Flask==2.3.2
 Flask-Markdown
 Flask-Misaka
 Flask-WTF
+feedparser==6.0.10
 globus-sdk==2.0.1
 geopy
 gunicorn==20.1.0


### PR DESCRIPTION
The goal was to automate the "News" tab on Portal's main page by populating it with new blog posts coming from SLATE's website. This was accomplished with the [feedparser](https://pypi.org/project/feedparser/) library for Python. The code is executed in the `views.py` file where the new code replaces the old code of passing through the `news.md` static page, which was subsequently deleted. The `feedparser` library dependency is added to the Docker image. 